### PR TITLE
 Remove leading/trailing whitespace from filename.

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -331,7 +331,7 @@ function generateFileName(extension, type) {
   } else {
     filename = filename + '.' + extension;
   }
-  filename = filename.replace(/[/\\?%*:|"<>]/g, '-');
+  filename = filename.replace(/[/\\?%*:|"<>]/g, '-').trim();
   return filename;
 }
 


### PR DESCRIPTION
Pages with a title such as <title>foo / bar</title> will result in a
filename like " bar" on Chrome. On linux, this seems to result in Chrome
finding the filename to be invalid (not entirely sure why, since most FS
will allow a leading space), and the clip fails silently.

This PR calls trim() on the final filename to allow it to save.

Another option would be to use something like
https://github.com/parshap/node-sanitize-filename, thus not discarding
the part of the title  but I don't know
enough about Javascript/extension conventions to determine whether
adding an additional dependency makes sense or it's worth rewriting this
function.